### PR TITLE
Update Dockerfile

### DIFF
--- a/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
+++ b/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
@@ -21,9 +21,10 @@ RUN apt-get install ruby ruby-dev build-essential -y && \
 
 WORKDIR /root/${app_name}
 
-# Set up virtual environment:
+# Set up virtual environment, upgrade pip, and install requirements:
 ADD *.txt /tmp/requirements/
 RUN python3.6 -m venv venv && \
+    venv/bin/python -m pip install --upgrade pip && \
     venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 


### PR DESCRIPTION
have had some stuff fail due to the low default pip version and needed this mod to ensure pip was upgraded before installing the requirements.

Error:
```
Step 9/17 : RUN python3.6 -m venv venv &&     venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 ---> Running in f5dc00354e5f
Collecting PyQt5==5.15.0 (from -r /tmp/requirements/ubuntu.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/8c/90/82c62bbbadcca98e8c6fa84f1a638de1ed1c89e85368241e9cc43fcbc320/PyQt5-5.15.0.tar.gz (3.3MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib/python3.6/tokenize.py", line 452, in open
        buffer = _builtin_open(filename, 'rb')
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-mo1jwje0/PyQt5/setup.py'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-mo1jwje0/PyQt5/
You are using pip version 18.1, however version 20.2b1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

After this mod installs this same PyQt5 version without issues in docker which is needed alongside the PyQtWebEngine latest vs the 5.9.2 default. Same mod might also be needed in the other linux os docker files to ensure its always using the latest pip.